### PR TITLE
Support origin and alter

### DIFF
--- a/test/MEGAMI_SALE.js
+++ b/test/MEGAMI_SALE.js
@@ -48,18 +48,108 @@ describe("MEGAMI_Sale", function () {
     it("can get starting price right after the DA starts", async function () {
         now = (await provider.getBlock(await provider.getBlockNumber())).timestamp;
 
-        // DA started 1 sec 
-        await auction.setStart(now - 1);
-        
-        // Start Price
-        expect((await auction.currentPrice(0))).to.equal(parseEther("0.2")); 
+        cases = [
+            // wave, tokenId, expected starting price
+            // Wave 0
+            [0, 0,       "10"], // Origin start
+            [0, 2,       "10"], // Origin end
+            [0, 3,        "5"], // Alter start
+            [0, 4,        "5"], // Alter end
+            [0, 5,      "0.2"], // Genearted start
+            [0, 999,    "0.2"], // Generated end
+            // Wave 3
+            [3, 3000,    "10"], // Origin start
+            [3, 3002,    "10"], // Origin end
+            [3, 3003,     "5"], // Alter start
+            [3, 3004,     "5"], // Alter end
+            [3, 3005,   "0.2"], // Genearted start
+            [3, 3999,   "0.2"], // Generated end            
+            // Wave 4
+            [4, 4000,    "10"], // Origin start
+            [4, 4002,    "10"], // Origin end
+            [4, 4003,     "5"], // Alter start
+            [4, 4005,     "5"], // Alter end
+            [4, 4006,   "0.2"], // Genearted start
+            [4, 4999,   "0.2"], // Generated end
+            // Wave 7
+            [7, 7000,    "10"], // Origin start
+            [7, 7002,    "10"], // Origin end
+            [7, 7003,     "5"], // Alter start
+            [7, 7005,     "5"], // Alter end
+            [7, 7006,   "0.2"], // Genearted start
+            [7, 7999,   "0.2"], // Generated end
+            // Wave 8
+            [8, 8000,    "10"], // Origin start
+            [8, 8002,    "10"], // Origin end
+            [8, 8003,     "5"], // Alter start
+            [8, 8004,     "5"], // Alter end
+            [8, 8006,   "0.2"], // Genearted start
+            [8, 8999,   "0.2"], // Generated end                 
+        ]
+
+        for(i = 0; i < cases.length; i++ ) {
+            // DA started 1 sec 
+            await auction.setStart(now - 1 - (60 * 60 * cases[i][0]));
+            
+            // Start Price
+            expect((await auction.currentPrice(cases[i][1]))).to.equal(parseEther(cases[i][2])); 
+        }
     });  
 
-    it("can get decreased price after price drops", async function () {
+    it("can get decreased price after price drops - origin", async function () {
         now = (await provider.getBlock(await provider.getBlockNumber())).timestamp;
 
         cases = [
             // tokenId, past minutes, expected current price
+            [0,    "10"],
+            [30,   "9.79"], 
+            [60,   "9.58"], 
+            [90,   "9.37"], 
+            [120,  "9.16"], 
+            [1380, "0.34"], 
+            [1410, "0.13"],
+            [1440, "0.08"], 
+            [1470, "0.08"]
+        ];
+        for(i = 0; i < cases.length; i++ ) {
+            // After 5 * i min and 1 sec
+            await auction.setStart(now - 1 - (60 * cases[i][0])); 
+
+            // Start Price - 0.05 * i
+            expect((await auction.currentPrice(0))).to.equal(parseEther(cases[i][1])); 
+        };
+    });
+
+    it("can get decreased price after price drops - alter", async function () {
+        now = (await provider.getBlock(await provider.getBlockNumber())).timestamp;
+
+        cases = [
+            // tokenId, past minutes, expected current price
+            [0,    "5"],
+            [30,   "4.8975"], 
+            [60,   "4.795"], 
+            [90,   "4.6925"], 
+            [120,  "4.59"], 
+            [1380, "0.285"], 
+            [1410, "0.1825"],
+            [1440, "0.08"], 
+            [1470, "0.08"]
+        ];
+        for(i = 0; i < cases.length; i++ ) {
+            // After 5 * i min and 1 sec
+            await auction.setStart(now - 1 - (60 * cases[i][0])); 
+
+            // Start Price - 0.05 * i
+            expect((await auction.currentPrice(3))).to.equal(parseEther(cases[i][1])); 
+        };
+    });
+
+    it("can get decreased price after price drops - generated", async function () {
+        now = (await provider.getBlock(await provider.getBlockNumber())).timestamp;
+
+        cases = [
+            // tokenId, past minutes, expected current price
+            [0,    "0.2"],
             [30,   "0.1975"], 
             [60,   "0.195"], 
             [90,   "0.1925"], 
@@ -74,7 +164,7 @@ describe("MEGAMI_Sale", function () {
             await auction.setStart(now - 1 - (60 * cases[i][0])); 
 
             // Start Price - 0.05 * i
-            expect((await auction.currentPrice(0))).to.equal(parseEther(cases[i][1])); 
+            expect((await auction.currentPrice(10))).to.equal(parseEther(cases[i][1])); 
         };
     });
 
@@ -85,7 +175,7 @@ describe("MEGAMI_Sale", function () {
         await auction.setStart(now - 1 - (60 * 60 * 25)); 
 
         // Price shouldn't be lower than the ending price
-        expect((await auction.currentPrice(0))).to.equal(parseEther("0.08")); 
+        expect((await auction.currentPrice(10))).to.equal(parseEther("0.08")); 
     }); 
 
     it("price can be managed independently in each wave", async function () {
@@ -93,21 +183,21 @@ describe("MEGAMI_Sale", function () {
 
         cases = [
             // tokenId, past minutes, expected current price
-            [0,       0, "0.2"], 
-            [0,      60, "0.195"],
-            [1000,   60, "0.2"], 
-            [0,     120, "0.19"],
-            [1000,  120, "0.195"], 
-            [2000,  120, "0.2"],
-            [0,     540, "0.155"],
-            [1000,  540, "0.16"], 
-            [2000,  540, "0.165"],            
-            [8000,  540, "0.195"],
-            [9000,  540, "0.2"],
-            [8000, 1950, "0.08"],   // 24.5 hours after releasing wave 9
-            [9000, 1950, "0.0825"], // 23.5 hours after releasing wave 10
-            [8000, 2010, "0.08"],   // 25.5 hours after releasing wave 9
-            [9000, 2010, "0.08"], // 24.5 hours after releasing wave 10            
+            [10,      0, "0.2"], 
+            [10,     60, "0.195"],
+            [1010,   60, "0.2"], 
+            [10,    120, "0.19"],
+            [1010,  120, "0.195"], 
+            [2010,  120, "0.2"],
+            [10,    540, "0.155"],
+            [1010,  540, "0.16"], 
+            [2010,  540, "0.165"],            
+            [8010,  540, "0.195"],
+            [9010,  540, "0.2"],
+            [8010, 1950, "0.08"],   // 24.5 hours after releasing wave 9
+            [9010, 1950, "0.0825"], // 23.5 hours after releasing wave 10
+            [8010, 2010, "0.08"],   // 25.5 hours after releasing wave 9
+            [9010, 2010, "0.08"], // 24.5 hours after releasing wave 10            
         ];
         for(i = 0; i < cases.length; i++ ) {
             await auction.setStart(now - 1 - (60 * cases[i][1])); 
@@ -122,7 +212,7 @@ describe("MEGAMI_Sale", function () {
         await auction.setStart(now + 10); 
 
         // Start Price
-        await expect(auction.currentPrice(0)).to.be.revertedWith("DA has not started!");
+        await expect(auction.currentPrice(10)).to.be.revertedWith("DA has not started!");
     });  
 
     it("DA start time should be managed independently", async function () {


### PR DESCRIPTION
- インフォグラフィックを元にOriginとAlterで価格体系を変更するロジックを実装しました。Originはwaveの最初の3つのトークン(0, 1, 2)、AlterはOriginの後に2つ(3, 4)、もしくは3つ(3, 4, 5)を割り当てています。なお、Alterは総数が24で、各waveに均等に割り当てることができないため、wave4-7で3つづつリリースされるようにしています。