### PR TITLE
Add getUnmintedTokenIds

### DIFF
--- a/contracts/MEGAMI.sol
+++ b/contracts/MEGAMI.sol
@@ -52,6 +52,22 @@ contract MEGAMI is ERC721, Ownable, ReentrancyGuard, RoyaltiesV2 {
         super._beforeTokenTransfer(from, to, tokenId);
     }
 
+    /**
+     * @dev Since MEGAMI isn't minting tokens sequentially, this function scans all of minted tokens and returns unminted tokenIds
+     */
+    function getUnmintedTokenIds() public view returns (uint256[] memory) {
+        uint256[] memory unmintedTokenIds = new uint256[](_maxSupply - totalSupply);
+        uint256 unmintedCount = 0;
+        for (uint256 i = 0; i < _maxSupply;) {
+            if(!_exists(i)) {
+                unmintedTokenIds[unmintedCount] = i;
+                unchecked { ++unmintedCount; }
+            }
+            unchecked { ++i; }
+        }
+        return unmintedTokenIds;
+    }
+
     function mint(uint256 _tokenId, address _address) public onlyOwnerORSaleContract nonReentrant { 
         require(totalSupply <= _maxSupply, "minting limit");
 

--- a/contracts/MEGAMI_SALE.sol
+++ b/contracts/MEGAMI_SALE.sol
@@ -173,6 +173,10 @@ contract MEGAMI_Sale is Ownable {
         DA_ENDING_TIMESTAMP = DA_STARTING_TIMESTAMP + DA_LENGTH;
     }
 
+    function getUnmintedTokenIds() external view returns (uint256[] memory) {
+        return MEGAMI_TOKEN.getUnmintedTokenIds();
+    }
+
     //VARIABLES THAT NEED TO BE SET BEFORE MINT(pls remove comment when uploading to mainet)
     function setSigner(address signer) external onlyOwner {
         mlSigner = signer;

--- a/test/MEGAMI.js
+++ b/test/MEGAMI.js
@@ -1,5 +1,5 @@
 const { AddressZero } = require('@ethersproject/constants');
-const { expect } = require("chai");
+const { expect, assert } = require("chai");
 
 describe("MEGAMI", function () {
 beforeEach(async function () {
@@ -31,6 +31,25 @@ beforeEach(async function () {
       expect(await megami.connect(owner).mint(10, minter.address)).to.emit(megami, 'Transfer').withArgs(AddressZero, minter.address, 10);
 
       await expect(megami.connect(owner).mint(10, minter.address)).to.be.revertedWith("ERC721: token already minted");
+    });
+
+    // --- getUnmintedTokenIds tests ---
+    it("Should return unmintedTokenIds", async function() {
+      // Initial remaining tokenIds sould be 10,000
+      expect((await megami.getUnmintedTokenIds())).to.have.lengthOf(10000);
+
+      // Mint token ID 10
+      expect(await megami.connect(owner).mint(10, minter.address)).to.emit(megami, 'Transfer').withArgs(AddressZero, minter.address, 10);
+
+      // Initial remaining tokenIds sould be 9,999
+      const unmintedIds = await megami.getUnmintedTokenIds();
+      expect(unmintedIds).to.have.lengthOf(9999);
+
+      for(i = 0; i < unmintedIds.length; i++ ){
+        if(unmintedIds[i] == 10) {
+          assert.fail();
+        }
+      }
     });
 
     // --- Royalty tests ---

--- a/test/MEGAMI_SALE.js
+++ b/test/MEGAMI_SALE.js
@@ -361,4 +361,12 @@ describe("MEGAMI_Sale", function () {
     it("non owner should not be able to mint through mintTeam", async function () {     
         await expect(auction.connect(minter).mintTeam(minter.address, [10, 11, 15])).to.be.revertedWith("Ownable: caller is not the owner");
     }); 
+
+    // --- getUnmintedTokenIds tests ---
+    it("Should return unmintedTokenIds", async function() {
+        // Just do the simple testing here because this function is just calling MEGAMI contract which is tested separately
+        
+        // Initial remaining tokenIds sould be 10,000
+        expect((await megamiContract.getUnmintedTokenIds())).to.have.lengthOf(10000);
+    });
 });


### PR DESCRIPTION
- ミントされていないIDの一覧を返す`getUnmintedTokenIds`関数を追加しました。

ただこの関数、マップの中身を全部なめるのでものすごく遅くてテストだと7秒以上かかっています。
テストネットでもこのスピードだとすると、WAVE毎に返す関数にして並列で呼び出すみたいな細工が必要かもしれません。

`Should return unmintedTokenIds (7335ms)`