### PR TITLE
Add withdraw functions

### DIFF
--- a/test/MEGAMI.js
+++ b/test/MEGAMI.js
@@ -1,5 +1,9 @@
 const { AddressZero } = require('@ethersproject/constants');
 const { expect, assert } = require("chai");
+const { parseEther } = require('ethers/lib/utils');
+const { waffle } = require("hardhat");
+
+const provider = waffle.provider;
 
 describe("MEGAMI", function () {
 beforeEach(async function () {
@@ -147,4 +151,91 @@ beforeEach(async function () {
       // owner shound't be changed
       expect((await megami.owner()).toString()).to.equal(owner.address);
     });   
+
+    // --- test setFeeReceivers ---
+    it("Should be able to set feeReceivers", async function() {
+      await (expect(megami.setFeeReceivers([[owner.address, 5000], [seller.address, 3000], [other.address, 2000]]))).to.be.not.reverted;
+    })
+
+    it("Should fail to set feeReceivers if receivers are empty ", async function() {
+      await (expect(megami.setFeeReceivers([]))).to.be.revertedWith("at least one receiver is necessary");
+    })    
+
+    it("Should fail to set feeReceivers if receivers contain a zero address ", async function() {
+      await (expect(megami.setFeeReceivers([[owner.address, 5000], [seller.address, 3000], [AddressZero, 2000]]))).to.be.revertedWith("receiver address can't be null");
+    })  
+
+    it("Should fail to set feeReceivers if share percentage basis point is 0", async function() {
+      await (expect(megami.setFeeReceivers([[owner.address, 5000], [seller.address, 0], [other.address, 2000]]))).to.be.revertedWith("share percentage basis points can't be 0");
+    })  
+
+    it("Should fail to set feeReceivers if total share percentage basis point isn't 10000 ", async function() {
+      await (expect(megami.setFeeReceivers([[owner.address, 2000], [seller.address, 2000], [other.address, 2000]]))).to.be.revertedWith("total share percentage basis point isn't 10000");
+    })
+
+    // --- test withdraw ---
+    it("Should distribute fee to feeReceivers", async function() {
+      // Give 100 ETH to the contract
+      await minter.sendTransaction({to: megami.address, value: parseEther("100")});
+
+      // Set feeReceivers
+      await (expect(megami.setFeeReceivers([[owner.address, 5000], [seller.address, 3000], [other.address, 2000]]))).to.be.not.reverted;
+
+      const tx = megami.withdraw();
+      await expect(tx).to.be.not.reverted;
+      await expect(await tx).to.changeEtherBalance(owner, parseEther("50"));
+      await expect(await tx).to.changeEtherBalance(seller, parseEther("30"));
+      await expect(await tx).to.changeEtherBalance(other, parseEther("20"));
+
+      // contract's wallet balance should be 0
+      expect((await provider.getBalance(megami.address)).toString()).to.equal("0");
+    })
+
+    it("Should distribute fee to a single feeReceiver", async function() {
+      // Give 100 ETH to the contract
+      await minter.sendTransaction({to: megami.address, value: parseEther("100")});
+
+      // Set feeReceivers
+      await (expect(megami.setFeeReceivers([[other.address, 10000]]))).to.be.not.reverted;
+
+      const tx = megami.withdraw();
+      await expect(tx).to.be.not.reverted;
+      await expect(await tx).to.changeEtherBalance(other, parseEther("100"));
+
+      // contract's wallet balance should be 0
+      expect((await provider.getBalance(megami.address)).toString()).to.equal("0");
+    })
+
+    it("Should distribute fee to feeReceivers with remainder", async function() {
+      // Give 5 wei to the contract
+      await minter.sendTransaction({to: megami.address, value: 5});
+
+      // Set feeReceivers
+      await (expect(megami.setFeeReceivers([[owner.address, 5000], [seller.address, 3000], [other.address, 2000]]))).to.be.not.reverted;
+
+      const tx = megami.withdraw();
+      await expect(tx).to.be.not.reverted;
+      await expect(await tx).to.changeEtherBalance(owner, 3); // 2 + leftover 1
+      await expect(await tx).to.changeEtherBalance(seller, 1);
+      await expect(await tx).to.changeEtherBalance(other, 1);
+
+      // contract's wallet balance should be 0
+      expect((await provider.getBalance(megami.address)).toString()).to.equal("0");
+    })
+
+    it("withdraw should fail if feeReceivers is empty", async function() {
+      await expect(megami.withdraw()).to.be.revertedWith("receivers haven't been specified yet");
+    })    
+    
+    it("emergencyWithdraw should send fund to owner", async function() {
+      // Give 100 ETH to the contract
+      await minter.sendTransaction({to: megami.address, value: parseEther("100")});
+
+      const tx = megami.emergencyWithdraw();
+      await expect(tx).to.be.not.reverted;
+      await expect(await tx).to.changeEtherBalance(owner, parseEther("100"));
+
+      // contract's wallet balance should be 0
+      expect((await provider.getBalance(megami.address)).toString()).to.equal("0");
+    })         
 });


### PR DESCRIPTION
- withdraw関連の関数を追加しました

NFTコントラクトにはファンドの受信アドレスと割り当てを保有するリストを作成し、withdraw時に指定された割合でファンドの転送が行われるように実装しました。なお端数が出た場合は1番目のアドレスが受け取ります。

セールスコントラクトにはファンドを配布する機能は持たせず、NFT側にファンドを転送する関数`moveFund`のみを持たせました。そのため、販売完了後はNFTコントラクトにファンドを転送し、NFTコントラクトからファンドを分配することになります。

なお、両コントラクト共にオーナー専用機能として`emergencyWithdraw`関数を実装しています。これは上述の関数に不具合があった場合に緊急避難的にオーナーへファンドを転送するためです。

ガス代
```
·--------------------------------------------------------|----------------------------|-------------|-----------------------------·
|                  Solc version: 0.8.7                   ·  Optimizer enabled: false  ·  Runs: 200  ·  Block limit: 30000000 gas  │
·························································|····························|·············|······························
|  Methods                                                                                                                        │
················|········································|··············|·············|·············|···············|··············
|  Contract     ·  Method                                ·  Min         ·  Max        ·  Avg        ·  # calls      ·  eur (avg)  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI_Sale  ·  emergencyWithdraw                     ·           -  ·          -  ·      30603  ·            2  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI_Sale  ·  mintDA                                ·           -  ·          -  ·     162272  ·            4  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI_Sale  ·  mintPublic                            ·           -  ·          -  ·     110945  ·            4  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI_Sale  ·  mintTeam                              ·           -  ·          -  ·     167068  ·            4  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI_Sale  ·  moveFund                              ·           -  ·          -  ·      35299  ·            2  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI_Sale  ·  setDutchActionActive                  ·           -  ·          -  ·      27064  ·            8  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI_Sale  ·  setPublicSaleActive                   ·           -  ·          -  ·      27039  ·            4  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI_Sale  ·  setSigner                             ·           -  ·          -  ·      46339  ·            6  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI_Sale  ·  setStart                              ·       30840  ·      70640  ·      39395  ·           98  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI       ·  emergencyWithdraw                     ·           -  ·          -  ·      30558  ·            2  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI       ·  mint                                  ·      101347  ·     103575  ·     103319  ·            9  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI       ·  renounceOwnership                     ·           -  ·          -  ·      23559  ·            1  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI       ·  setDefaultPercentageBasisPoints       ·           -  ·          -  ·      29061  ·            1  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI       ·  setDefaultRoyaltiesReceipientAddress  ·           -  ·          -  ·      29240  ·            1  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI       ·  setFeeReceivers                       ·       71937  ·     122709  ·     110016  ·            4  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI       ·  setSaleContract                       ·       46351  ·      46363  ·      46361  ·           29  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  MEGAMI       ·  withdraw                              ·       37720  ·      60760  ·      56152  ·           10  ·          -  │
················|········································|··············|·············|·············|···············|··············
|  Deployments                                           ·                                          ·  % of limit   ·             │
·························································|··············|·············|·············|···············|··············
|  MEGAMI                                                ·           -  ·          -  ·    4302861  ·       14.3 %  ·          -  │
·························································|··············|·············|·············|···············|··············
|  MEGAMI_Sale                                           ·     3173540  ·    3173552  ·    3173551  ·       10.6 %  ·          -  │
·--------------------------------------------------------|--------------|-------------|-------------|---------------|-------------·
```

カバレッジ
```
----------------------------------------|----------|----------|----------|----------|----------------|
File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------------------------|----------|----------|----------|----------|----------------|
 contracts/                             |       97 |    86.76 |    90.91 |    97.22 |                |
  MEGAMI.sol                            |    95.92 |    81.25 |    88.89 |    96.36 |         99,100 |
  MEGAMI_SALE.sol                       |    98.04 |    91.67 |    93.33 |    98.11 |            178 |
 contracts/rarible/royalties/contracts/ |        0 |      100 |        0 |        0 |                |
  LibPart.sol                           |        0 |      100 |        0 |        0 |             14 |
  LibRoyaltiesV2.sol                    |      100 |      100 |      100 |      100 |                |
  RoyaltiesV2.sol                       |      100 |      100 |      100 |      100 |                |
----------------------------------------|----------|----------|----------|----------|----------------|
All files                               |    96.04 |    86.76 |    88.24 |    96.33 |                |
----------------------------------------|----------|----------|----------|----------|----------------|
```