### PR TITLE
Make the baseTokenURI updatable

### DIFF
--- a/contracts/MEGAMI.sol
+++ b/contracts/MEGAMI.sol
@@ -20,7 +20,7 @@ contract MEGAMI is ERC721, Ownable, ReentrancyGuard, RoyaltiesV2 {
 
     uint256 public totalSupply = 0;
 
-    string private constant _baseTokenURI = "ipfs://xxxxx/";
+    string private _baseTokenURI = "ipfs://xxxxx/";
 
     // Royality management
     address payable public defaultRoyaltiesReceipientAddress;  // This will be set in the constructor
@@ -68,6 +68,14 @@ contract MEGAMI is ERC721, Ownable, ReentrancyGuard, RoyaltiesV2 {
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
         require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
         return string(abi.encodePacked(_baseTokenURI, tokenId.toString(), ".json"));
+    }
+
+    /**
+     * @dev Set baseTokenURI.
+     * @param newBaseTokenURI The value being set to baseTokenURI.
+     */
+    function setBaseTokenURI(string calldata newBaseTokenURI) external onlyOwner {
+        _baseTokenURI = newBaseTokenURI;
     }
 
     // Copied from ForgottenRunesWarriorsGuild. Thank you dotta ;)

--- a/test/MEGAMI.js
+++ b/test/MEGAMI.js
@@ -120,12 +120,21 @@ beforeEach(async function () {
       // mint by owner
       expect(await megami.connect(owner).mint(10, other.address));
 
-      expect((await megami.tokenURI(10))).to.equal("ipfs://xxxxx/10.json")
+      expect((await megami.tokenURI(10))).to.equal("ipfs://xxxxx/10.json");
     });
 
     it("token URI must be return error for unminted token Id", async function() {
       await expect(megami.tokenURI(10)).to.be.revertedWith("ERC721Metadata: URI query for nonexistent token");
-    });      
+    });
+
+    it("base token URI should be updatable", async function() {
+      await megami.setBaseTokenURI("ipfs://yyyyy/");
+      
+      // mint by owner
+      expect(await megami.connect(owner).mint(10, other.address));
+
+      expect((await megami.tokenURI(10))).to.equal("ipfs://yyyyy/10.json");
+    });
 
     // --- test ownership ---
     it("renounceOwnership should be NOP", async function () {


### PR DESCRIPTION
- baseTokenURIを更新可能にしました。リビールは行いませんが、なにかメタデータに不具合があった際の更新等に利用できます。