### PR TITLE
Use Infura instead of Alchemy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn test:gas
 ## Deploy
 Rinkeby
 ```
-ALCHEMY_API_KEY=<Alchemy API Key> RINKEBY_PRIVATE_KEY=<Rinkeby Wallet Private Key> ETHERSCAN_API_KEY=<Etherscan API Key> yarn deploy:rinkeby
+INFURA_API_KEY=<Alchemy API Key> RINKEBY_PRIVATE_KEY=<Rinkeby Wallet Private Key> ETHERSCAN_API_KEY=<Etherscan API Key> yarn deploy:rinkeby
 ```
 
 You may see verification errors, but you can ignore them if their `Reason` is `Already Verified`.

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,7 +4,7 @@ require("hardhat-gas-reporter");
 require("solidity-coverage")
 require("@nomiclabs/hardhat-etherscan");
 
-const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY;
+const INFURA_API_KEY = process.env.INFURA_API_KEY;
 
 /**
  * @type import('hardhat/config').HardhatUserConfig
@@ -13,7 +13,7 @@ module.exports = {
   solidity: "0.8.7",
   networks: {
     rinkeby: {
-      url: `https://eth-rinkeby.alchemyapi.io/v2/${ALCHEMY_API_KEY}`,
+      url: `https://rinkeby.infura.io/v3/${INFURA_API_KEY}`,
       accounts: [process.env.RINKEBY_PRIVATE_KEY]
     }
   },

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -25,6 +25,11 @@ async function main() {
 
     console.log("MEGAMISales address:", megamiSales.address);
   
+    // We need to wait until Etherscan create a cache of our contracts
+    console.log("Waiting 1 minute for making sure bytecode being cached by etherscan");
+    const sleep = ms => new Promise(r => setTimeout(r, ms));
+    await sleep(60000);
+
     console.log("Verifying FundManager");
 
     try {


### PR DESCRIPTION
- デプロイにInfuraを使うよう変更しました。これに伴い指定する環境変数も`INFURA_API_KEY`に変更されています。
- Infuraはデプロイがとても早いので、Verifyの前にEtherscanがbytecodeをキャッシュするまで1分間待機する処理を入れました