### PR TITLE
Address to review feedback 2

### DIFF
--- a/contracts/FundManager.sol
+++ b/contracts/FundManager.sol
@@ -37,6 +37,7 @@ contract FundManager is Ownable {
     function setFeeReceivers(FundReceiver[] calldata receivers) external onlyOwner {
         uint256 receiversLength = receivers.length;
         require(receiversLength > 0, "at least one receiver is necessary");
+        require(receiversLength <= 50, "too many receivers");
         uint256 totalPercentageBasisPoints = 0;
         delete _fundReceivers;
         for(uint256 i = 0; i < receiversLength;) {

--- a/contracts/MEGAMI.sol
+++ b/contracts/MEGAMI.sol
@@ -58,6 +58,11 @@ contract MEGAMI is IMEGAMI, ERC721, Ownable, ReentrancyGuard, RoyaltiesV2 {
     uint256 private constant HUNDRED_PERCENT_IN_BASIS_POINTS = 10000;
 
     /**
+     * @dev Max royalty this contract allows to set. It's 15% in the basis points.
+     */
+    uint256 private constant MAX_ROYALTY_BASIS_POINTS = 1500;
+
+    /**
      * @dev Constractor of MEGAMI contract. Setting the fund manager and royalty recipient.
      * @param fundManagerContractAddress Address of the contract managing funds.
      */
@@ -132,7 +137,7 @@ contract MEGAMI is IMEGAMI, ERC721, Ownable, ReentrancyGuard, RoyaltiesV2 {
      * @param newDefaultPercentageBasisPoints The new percentagy basis points of the loyalty.
      */
     function setDefaultPercentageBasisPoints(uint96 newDefaultPercentageBasisPoints) external onlyOwner {
-        require(newDefaultPercentageBasisPoints < HUNDRED_PERCENT_IN_BASIS_POINTS, "must be less than 100%");
+        require(newDefaultPercentageBasisPoints <= MAX_ROYALTY_BASIS_POINTS, "must be less than or equal to 15%");
         defaultPercentageBasisPoints = newDefaultPercentageBasisPoints;
     }
 

--- a/contracts/MEGAMISales.sol
+++ b/contracts/MEGAMISales.sol
@@ -165,7 +165,7 @@ contract MEGAMISales is ReentrancyGuard, Ownable {
             "DA has not started!"
         );        
 
-        require(block.timestamp <= getAuctoinEndTime(), "DA is finished");
+        require(block.timestamp <= getAuctionEndTime(), "DA is finished");
 
         // Validate Mintlist
         // Message format is 1 byte shifted address + number of MLs (1 byte)
@@ -356,7 +356,7 @@ contract MEGAMISales is ReentrancyGuard, Ownable {
     /**
      * @dev Returns the end time of the auction in unix timestamp format.
      */
-    function getAuctoinEndTime() public view returns (uint256) {
+    function getAuctionEndTime() public view returns (uint256) {
         return auctionStartingTimestamp + AUCTION_LENGTH;
     }
     

--- a/test/FundManager.js
+++ b/test/FundManager.js
@@ -38,6 +38,24 @@ beforeEach(async function () {
         await (expect(fundManager.setFeeReceivers([[r1.address, 2000], [r2.address, 2000], [r3.address, 2000]]))).to.be.revertedWith("total share percentage basis point isn't 10000");
       })
 
+      it("Should fail to set more than 50 receivers", async function() {
+        let receivers = [];
+        for(i = 0; i < 50; i++) {
+          receivers.push([r1.address, 100]);
+        }
+        receivers.push([r1.address, 5000]);
+        await expect(fundManager.setFeeReceivers(receivers)).to.be.revertedWith("too many receivers");
+      });
+
+      it("Should be able to set up to 50 receivers", async function() {
+        let receivers = [];
+        for(i = 0; i < 49; i++) {
+          receivers.push([r1.address, 100]);
+        }
+        receivers.push([r1.address, 5100]);
+        await expect(fundManager.setFeeReceivers(receivers)).to.not.be.reverted;
+      });
+
     // --- test withdraw ---
     it("Should distribute fee to feeReceivers", async function() {
       // Give 100 ETH to the contract

--- a/test/MEGAMI.js
+++ b/test/MEGAMI.js
@@ -75,8 +75,13 @@ beforeEach(async function () {
 
     it("Should fail to set invalid percentage to the defaultPercentageBasisPoints", async function () {
       // set new defaultPercentageBasisPoints
-      await expect(megami.setDefaultPercentageBasisPoints(10000)).to.revertedWith("must be less than 100%");
+      await expect(megami.setDefaultPercentageBasisPoints(1501)).to.revertedWith("must be less than or equal to 15%");
     });  
+
+    it("Should be able to set the royalty percentage up-to 15%", async function () {
+      // set new defaultPercentageBasisPoints
+      await expect(megami.setDefaultPercentageBasisPoints(1500)).to.not.be.reverted;
+    });     
 
     it("Should return correct royalty through getRaribleV2Royalties", async function () {
       // get royalty through Rarible's interface


### PR DESCRIPTION
- ligaratusからのReviewフィードバックに対応し、Royaltyの設定可能最大値を15%に設定しました。この設定はなくても問題ないが、異常値の設定ができないようにしておくのはコントラクト開発のベストプラクティスとのことなので対応しました。
- KiwiからのReviewフィードバックに対応し、無制限のループが発生しないようFundManagerの配布先に上限を設定(50)しました。Kiwi的には運用問題ないので対応する必要はないということでしたが、コントラクトのAuditにかけると大体指摘される事項なので、念の為指摘したとのことでした。
- Kiwiから指摘のあったtypoを修正しました